### PR TITLE
Update link to our jobs page.

### DIFF
--- a/content/departments/people-talent/resources-for-new-hires/new-teammate-setup.md
+++ b/content/departments/people-talent/resources-for-new-hires/new-teammate-setup.md
@@ -19,7 +19,7 @@ Visit [this handbook page](../../tech-ops/tools/computer-setup.md) to know the r
 4. Choose **Insert image** and then **Web Address (URL)** and enter https://user-images.githubusercontent.com/3173176/115082082-2d892380-9eba-11eb-9606-6c4b9c4eb465.png then choose **Small** size after it has been entered.
 5. Click the image, then click **Link** and paste https://sourcegraph.com into the **Web Address** field. Now your image links to the website!
 6. Your signature should now look something like this, and clicking the Sourcegraph logo should bring you to sourcegraph.com:
-7. You may wish to add another line like `What is Universal Code Search? | We're hiring!` with links to https://about.sourcegraph.com/ and https://about.sourcegraph.com/careers.
+7. You may wish to add another line like `What is Universal Code Search? | We're hiring!` with links to https://about.sourcegraph.com/ and https://about.sourcegraph.com/jobs.
 
 <img width="464" alt="image" src="https://user-images.githubusercontent.com/3173176/115082263-7a6cfa00-9eba-11eb-93ba-61b72de8b30b.png">
 


### PR DESCRIPTION
The previous link pointed to https://about.sourcegraph.com/careers which is now obsolete. So we're now using https://about.sourcegraph.com/jobs instead.